### PR TITLE
Add RUC LSM option to land perturbations, add snow albedo and albedo to perturbed parameters

### DIFF
--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -294,7 +294,7 @@ module compns_stochy_mod
             'land perturbations will be applied to selected paramaters, using newer scheme designed for DA ens spread'
                do k =1,n_var_lndp
                    select case (lndp_var_list(k))
-                   case('vgf','smc','stc') 
+                   case('vgf','smc','stc','alb', 'sal') 
                        if (me==0) print*, 'land perturbation will be applied to ', lndp_var_list(k)
                    case default
                       print*, 'ERROR: land perturbation requested for new parameter - will need to be coded in lndp_apply_pert', lndp_var_list(k)

--- a/compns_stochy.F90
+++ b/compns_stochy.F90
@@ -294,7 +294,7 @@ module compns_stochy_mod
             'land perturbations will be applied to selected paramaters, using newer scheme designed for DA ens spread'
                do k =1,n_var_lndp
                    select case (lndp_var_list(k))
-                   case('vgf','smc','stc','alb', 'sal') 
+                   case('vgf','smc','stc','alb', 'sal','emi') 
                        if (me==0) print*, 'land perturbation will be applied to ', lndp_var_list(k)
                    case default
                       print*, 'ERROR: land perturbation requested for new parameter - will need to be coded in lndp_apply_pert', lndp_var_list(k)

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -21,26 +21,25 @@ module lndp_apply_perts_mod
                 lndp_prt_list, sfc_wts, xlon, xlat, stype, smcmax, smcmin,            &
                 param_update_flag,                                                    & 
                 smc, slc, stc, vfrac, alvsf, alnsf, alvwf, alnwf, facsf, facwf,       &
-                snoalb, ierr) 
-                !snoalb, semis, ierr) 
+                snoalb, semis, ierr) 
 
         implicit none
 
         ! intent(in) 
-        integer,                  intent(in) :: blksz(:)
-        integer,                  intent(in) :: n_var_lndp, lsoil, lsm
-        integer,                  intent(in) :: lsoil_lsm, lsm_ruc
-        character(len=3),         intent(in) :: lndp_var_list(:)
+        integer,                      intent(in) :: blksz(:)
+        integer,                      intent(in) :: n_var_lndp, lsoil, lsm
+        integer,                      intent(in) :: lsoil_lsm, lsm_ruc
+        character(len=3),             intent(in) :: lndp_var_list(:)
         real(kind=kind_dbl_prec),     intent(in) :: lndp_prt_list(:)
         real(kind=kind_dbl_prec),     intent(in) :: dtf
         real(kind=kind_dbl_prec),     intent(in) :: sfc_wts(:,:,:)
-        real(kind=kind_dbl_prec),     intent(in) :: xlon(:,:) 
-        real(kind=kind_dbl_prec),     intent(in) :: xlat(:,:) 
-        logical,                  intent(in) ::  param_update_flag    
+        real(kind=kind_dbl_prec),     intent(in) :: xlon(:,:)
+        real(kind=kind_dbl_prec),     intent(in) :: xlat(:,:)
+        logical,                      intent(in) ::  param_update_flag
                                         ! true =  parameters have been updated, apply perts
         real(kind=kind_dbl_prec),     intent(in) :: stype(:,:)
-        real(kind=kind_dbl_prec),     intent(in) :: smcmax(:) 
-        real(kind=kind_dbl_prec),     intent(in) :: smcmin(:) 
+        real(kind=kind_dbl_prec),     intent(in) :: smcmax(:)
+        real(kind=kind_dbl_prec),     intent(in) :: smcmin(:)
         real(kind=kind_dbl_prec),     intent(in) :: zs_lsm(:)
 
         ! intent(inout) 
@@ -55,7 +54,7 @@ module lndp_apply_perts_mod
         real(kind=kind_dbl_prec),     intent(inout) :: alnwf(:,:)
         real(kind=kind_dbl_prec),     intent(inout) :: facsf(:,:)
         real(kind=kind_dbl_prec),     intent(inout) :: facwf(:,:)
-        !real(kind=kind_dbl_prec),     intent(inout) :: semis(:,:)
+        real(kind=kind_dbl_prec),     intent(inout) :: semis(:,:)
 
         ! intent(out) 
         integer,                        intent(out) :: ierr
@@ -208,16 +207,16 @@ module lndp_apply_perts_mod
                          pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
                          call apply_pert ('snoalb',pert,print_flag, snoalb(nb,i), ierr,p,min_bound, max_bound)
                      !endif
-                !case('emi')  ! emissivity
-                !     if (param_update_flag) then
-                         !p =5.
-                         !min_bound=0.
-                         !max_bound=1.
+                case('emi')  ! emissivity
+                     !if (param_update_flag) then
+                         p =5.
+                         min_bound=0.
+                         max_bound=1.
 
-                        ! lndp_prt_list(v) = 0.1 (wrf)
-                         !pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
-                         !call apply_pert ('semis',pert,print_flag, semis(nb,i), ierr,p,min_bound, max_bound)
-                !     endif
+                         !lndp_prt_list(v) = 0.1 (wrf)
+                         pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
+                         call apply_pert ('semis',pert,print_flag, semis(nb,i), ierr,p,min_bound, max_bound)
+                     !endif
                 case default 
                     print*, &
                      'ERROR: unrecognised lndp_prt_list option in lndp_apply_pert, exiting', trim(lndp_var_list(v)) 

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -15,7 +15,6 @@ module lndp_apply_perts_mod
 !====================================================================
 ! Driver for applying perturbations to sprecified land states or parameters
 ! Draper, July 2020. 
-! Note on location: requires access to namelist_soilveg or namelist_soilveg_ruc
 
     subroutine lndp_apply_perts(blksz,lsm, lsoil, lsm_ruc, lsoil_lsm, zs_lsm,         &
                 dtf, n_var_lndp, lndp_var_list,                                       & 
@@ -211,13 +210,13 @@ module lndp_apply_perts_mod
                      !endif
                 !case('emi')  ! emissivity
                 !     if (param_update_flag) then
-                !         p =5.
-                !         min_bound=0.
-                !         max_bound=1.
+                         !p =5.
+                         !min_bound=0.
+                         !max_bound=1.
 
-                         ! lndp_prt_list(v) = 0.1 (wrf)
-                !         pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
-                !         call apply_pert ('semis',pert,print_flag, semis(nb,i), ierr,p,min_bound, max_bound)
+                        ! lndp_prt_list(v) = 0.1 (wrf)
+                         !pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
+                         !call apply_pert ('semis',pert,print_flag, semis(nb,i), ierr,p,min_bound, max_bound)
                 !     endif
                 case default 
                     print*, &

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -19,7 +19,7 @@ module lndp_apply_perts_mod
 
     subroutine lndp_apply_perts(blksz,lsm, lsoil, lsm_ruc, lsoil_lsm, zs_lsm,         &
                 dtf, n_var_lndp, lndp_var_list,                                       & 
-                lndp_prt_list, sfc_wts, xlon, xlat, stype, maxsmcnoah, maxsmc,        &
+                lndp_prt_list, sfc_wts, xlon, xlat, stype, smcmax, smcmin,            &
                 param_update_flag,                                                    & 
                 smc, slc, stc, vfrac, alvsf, alnsf, alvwf, alnwf, facsf, facwf,       &
                 snoalb, ierr) 
@@ -40,8 +40,8 @@ module lndp_apply_perts_mod
         logical,                  intent(in) ::  param_update_flag    
                                         ! true =  parameters have been updated, apply perts
         real(kind=kind_dbl_prec),     intent(in) :: stype(:,:)
-        real(kind=kind_dbl_prec),     intent(in) :: maxsmcnoah(:) 
-        real(kind=kind_dbl_prec),     intent(in) :: maxsmc(:) 
+        real(kind=kind_dbl_prec),     intent(in) :: smcmax(:) 
+        real(kind=kind_dbl_prec),     intent(in) :: smcmin(:) 
         real(kind=kind_dbl_prec),     intent(in) :: zs_lsm(:)
 
         ! intent(inout) 
@@ -94,7 +94,7 @@ module lndp_apply_perts_mod
         !write (0,*) 'lsm, lsoil, lsm_ruc, lsoil_lsm =', lsm, lsoil, lsm_ruc, lsoil_lsm
         !write (0,*) 'zs_lsm =', zs_lsm
         !write (0,*) 'n_var_lndp, lndp_var_list =', n_var_lndp, lndp_var_list
-        !write (0,*) 'maxsmcnoah, maxsmc =', maxsmcnoah, maxsmc
+        !write (0,*) 'smcmin =',smcmin
 
         zslayer(:) = 0.
         smc_vertscale(:) = 0.
@@ -144,9 +144,8 @@ module lndp_apply_perts_mod
                 case('smc') 
                     p=5. 
                     soiltyp  = int( stype(nb,i)+0.5 )  ! also need for maxsmc
-                    min_bound = minsmc
-                    max_bound = maxsmcnoah(soiltyp)
-                    !write (*,*) 'max_bound=', max_bound
+                    min_bound = smcmin(soiltyp)
+                    max_bound = smcmax(soiltyp)
                 
                     do k=1,nsoil
                          !store frozen soil moisture
@@ -163,7 +162,6 @@ module lndp_apply_perts_mod
                          ! assign all of applied pert to the liquid soil moisture 
                          slc(nb,i,k)  =  smc(nb,i,k) -  tmp_sic
                     enddo
-                    !write (0,*) 'nb, i, smc(nb,i,:)', nb, i, smc(nb,i,:)
 
                 case('stc') 
 
@@ -186,7 +184,6 @@ module lndp_apply_perts_mod
                          pert = sfc_wts(nb,i,v)*lndp_prt_list(v)
                          call apply_pert ('vfrac',pert,print_flag, vfrac(nb,i), ierr,p,min_bound, max_bound)
                      !endif
-                     !write (0,*) 'nb, i, vfrac(nb,i)', nb, i, vfrac(nb,i)
                 case('alb')  ! albedo
                      !if (param_update_flag) then
                          p =5.

--- a/lndp_apply_perts.F90
+++ b/lndp_apply_perts.F90
@@ -73,7 +73,7 @@ module lndp_apply_perts_mod
         !-- RUC lsm
         real(kind=kind_dbl_prec), dimension(9), parameter :: smc_vertscale_ruc = (/1.0,0.9,0.8,0.6,0.4,0.2,0.1,0.05,0./)
         real(kind=kind_dbl_prec), dimension(9), parameter :: stc_vertscale_ruc = (/1.0,0.9,0.8,0.6,0.4,0.2,0.1,0.05,0./)
-        real(kind=kind_dbl_prec), dimension(9), parameter :: zs_ruc = (/0.00, 0.05, 0.20, 0.40, 0.60, 1.00, 1.60, 2.20, 3.00/)
+        real(kind=kind_dbl_prec), dimension(9), parameter :: zs_ruc = (/0.05, 0.15, 0.20, 0.20, 0.40, 0.60, 0.60, 0.80, 1.00/)
 
         ierr = 0
 


### PR DESCRIPTION
This PR adds RUC LSM to the land perturbation code and also adds snow albedo and background albedo components to the perturbed parameters.

Associated PRs:

https://github.com/NOAA-GSL/stochastic_physics/pull/1
https://github.com/NOAA-GSL/ccpp-physics/pull/71
https://github.com/NOAA-GSL/fv3atm/pull/68 (contains https://github.com/NOAA-GSL/fv3atm/pull/65)
https://github.com/NOAA-GSL/ufs-weather-model/pull/57

See https://github.com/NOAA-GSL/ufs-weather-model/pull/57 for regression testing.